### PR TITLE
prevent firewall message in Macos

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/tapirliu/golf
+
+go 1.15

--- a/golf.go
+++ b/golf.go
@@ -93,7 +93,11 @@ func main() {
 	}()
 
 	handler := NoCacheHandler(http.FileServer(http.Dir(pwd)))
-	if err = http.ListenAndServe(":"+*port, handler); err != nil {
+  addr := ":"+*port
+  if runtime.GOOS == "darwin" {
+    addr = "localhost:" + *port
+  }
+	if err = http.ListenAndServe(addr, handler); err != nil {
 		log.Printf("Failed to start server: %v\n", err)
 	}
 }


### PR DESCRIPTION
A minor fix to prevent firewall message from coming up when running the server. Also added go.mod file.
Thanks,